### PR TITLE
implement smart cutoff :)

### DIFF
--- a/1-make_potentials/from_contact_values_to_potentials.sh
+++ b/1-make_potentials/from_contact_values_to_potentials.sh
@@ -25,6 +25,9 @@ symmetry="asymm"
 # any other value disables it
 ipc_model=0
 
+# lower threshold value for both potential and force
+cutoff=0.0001
+
 # parameters for the first patch
 
 
@@ -67,6 +70,7 @@ pushd sources
   # generate inputfile
   echo $model_name > inputfile
   echo $delta >> inputfile
+  echo $cutoff >> inputfile
   echo $ecc1 >> inputfile
   echo $rad1 >> inputfile
   echo $vEE >> inputfile

--- a/1-make_potentials/from_epsilon_to_potentials.sh
+++ b/1-make_potentials/from_epsilon_to_potentials.sh
@@ -25,6 +25,9 @@ symmetry="asymm"
 # any other value disables it
 ipc_model=0
 
+# lower threshold value for both potential and force
+cutoff=0.0001
+
 # parameters for the first patch
 
 
@@ -65,6 +68,7 @@ pushd sources
   # generate inputfile
   echo $model_name > inputfile
   echo $delta >> inputfile
+  echo $cutoff >> inputfile
   echo $ecc1 >> inputfile
   echo $rad1 >> inputfile
   echo $epsEE >> inputfile

--- a/1-make_potentials/sources/printPotential.hpp
+++ b/1-make_potentials/sources/printPotential.hpp
@@ -55,7 +55,7 @@ private:
   double eccentricity_p2, radius_p2;
   double HSdiameter, fakeHScoefficient, fakeHSexponent;
 
-  double samplingStep, cutoffValue;
+  double samplingStep, higherCutoff, lowerCutoff;
 
   std::vector<double> uHS, uBB, uBs1, uBs2, us1s2, us1s1, us2s2;
   std::vector<double> fHS, fBB, fBs1, fBs2, fs1s2, fs1s1, fs2s2;


### PR DESCRIPTION
A cutoff threshold is always read from file.

For the geometric mapping it's ignored: we cutoff when force and potential both go to zero, as this model does indeed go to zero.

For the exponential mapping, as soon as force OR potential go below the threshold (we could debate that it should be AND, not OR, but it seems to work fine either way) we cut.

Note that to implement this I am printing the files with a tag, and the replace the tag with sed. I have no idea how this would work not on Linux